### PR TITLE
feat: add `loadBalancerClass` and `annotations` templating for Service

### DIFF
--- a/aegis/Chart.yaml
+++ b/aegis/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/aegis/README.md
+++ b/aegis/README.md
@@ -37,6 +37,8 @@ A Helm chart for Kubernetes
 | secret.akeys.name | string | `"test-secret"` | name of the secret storing all the accesskey associated to configured kids |
 | secret.injectHeaders.name | string | `""` | optional secret name exposing env vars referenced by config.server.injectHeaders.*.valueFromEnv |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.loadBalancerClass | string | `""` | optional, used only if type == `LoadBalancer` |
 | service.port | int | `8080` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/aegis/templates/service.yaml
+++ b/aegis/templates/service.yaml
@@ -7,8 +7,17 @@ metadata:
   name: {{ include "aegis.fullname" . }}
   labels:
     {{- include "aegis.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.loadBalancerClass) }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/aegis/values.yaml
+++ b/aegis/values.yaml
@@ -43,6 +43,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
+  loadBalancerClass: "" # only used if type == LoadBalancer
+  annotations: {}
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Description

This PR adds new templating values for the Service in the Helm Chart, specifically:

- `service.annotations`
- `service.loadBalancerClass` - optional, only used if `service.type` is `LoadBalancer`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Run `helm template test <path> --values <path to values>` with:

- [x] Default values
- [x] Custom values file with `service.type: LoadBalancer`
- [x] Custom values file with `service.type: LoadBalancer` and `service.loadBalancerClass: tailscale`
- [x] Custom values file with `service.annotations: {"test": true}`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
