### PR TITLE
fix(handler): avoid upstream 301 redirects and stop on missing auth h…

### DIFF
--- a/aegis/Chart.yaml
+++ b/aegis/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "2.1.1"

--- a/server/handler.go
+++ b/server/handler.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -34,11 +35,23 @@ func (r *Router) Handler(ctx *gin.Context) {
 	}
 
 	director := func(req *http.Request) {
+
+		upstreamScheme := configuration.PROTOCOL_SCHEME
+		upstreamHost := r.conf.Server.Upstream
+		if parsedUpstream, err := url.Parse(r.conf.Server.Upstream); err == nil &&
+			parsedUpstream.Scheme != "" &&
+			parsedUpstream.Host != "" {
+			upstreamScheme = parsedUpstream.Scheme
+			upstreamHost = parsedUpstream.Host
+		}
+
 		req.Header = r.buildUpstreamHeaders(ctx.Request.Header)
-		req.Host = ctx.Request.Host
-		req.URL.Scheme = configuration.PROTOCOL_SCHEME
-		req.URL.Host = r.conf.Server.Upstream
+		req.Host = upstreamHost
+		req.URL.Scheme = upstreamScheme
+		req.URL.Host = upstreamHost
 		req.URL.Path = ctx.Request.URL.Path
+		req.URL.RawPath = ctx.Request.URL.RawPath
+		req.URL.RawQuery = ctx.Request.URL.RawQuery
 
 		if len(body) > 0 {
 			req.Body = io.NopCloser(bytes.NewBuffer(body))
@@ -89,18 +102,21 @@ func checkHeaders(ctx *gin.Context) (string, string, string) {
 
 	if authCorrelationId == "" {
 		ParamMissingError(ctx, configuration.AUTH_CORRELATIONID)
+		return "", "", ""
 	}
 
 	authKid := headers.Get(configuration.AUTH_KID)
 
 	if authKid == "" {
 		ParamMissingError(ctx, configuration.AUTH_KID)
+		return "", "", ""
 	}
 
 	signature := headers.Get(configuration.SIGNATURE)
 
 	if signature == "" {
 		ParamMissingError(ctx, configuration.SIGNATURE)
+		return "", "", ""
 	}
 
 	return authKid,

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@
 package main
 
 const (
-	VERSION string = "2.1.0"
+	VERSION string = "2.1.1"
 )
 
 var BUILDDATE = "NOW"


### PR DESCRIPTION
 ## Description

  This PR fixes request proxying issues in server/handler.go that could cause consistent 301 Moved Permanently responses and improves validation
  flow for missing auth headers.

  Main changes:

  - Set upstream request Host to upstream host (instead of client host) to avoid canonical-host redirects.
  - Resolve upstream scheme from server.upstream when provided (e.g. https://...), with http fallback.
  - Preserve URL components when forwarding (Path, RawPath, RawQuery).
  - Add early returns in checkHeaders after AbortWithError for missing required headers (Auth-CorrelationId, Auth-Kid, Signature) so no further
    handler logic runs on invalid input.


  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

  ## How Has This Been Tested?

  - [x] go test ./server

  Repro command:

  go test ./server

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] Docker image build

  ## Screenshots (if applicable)

  N/A